### PR TITLE
Changing how errors loading modules are handled

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -20,6 +20,7 @@ function register(app, options) {
       try {
         require(modulePath)(app);
       } catch (err) {
+        console.error(err)
       }
     }
   };


### PR DESCRIPTION
Debugging can be really difficult without any feedback at this point.

I would remove the try/catch entirely, but that could break existing applications relying on this to ignore not existing files.
